### PR TITLE
[Security] Add Security Champion to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.security/ @nan


### PR DESCRIPTION
Legger til `nan` som [Security Champion](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732332108/Security+Champion) i CODEOWNERS, der `nan` er GitHub-brukernavnet til den som skal være teamets kontaktperson om sikkerhet.