### PR TITLE
[Sikkerhet] Oppretter sikkerhetsfiler description.yaml og catalog-info.yaml og setter security champion i CODEOWNER

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+/.security/ @dagolav

--- a/.security/description.yaml
+++ b/.security/description.yaml
@@ -1,0 +1,4 @@
+organization: Land
+product: GeoNorge
+repo_types: [InternalApi,InternalClient,Experiment]
+platforms: [LOKALT]

--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -1,0 +1,12 @@
+# nonk8s
+apiVersion: "backstage.io/v1alpha1"
+kind: "Component"
+metadata:
+  name: "GeoGPT"
+  tags:
+  - "internal"
+spec:
+  type: "website"
+  lifecycle: "experimental"
+  owner: "datadeling_og_distribusjon"
+  system: "geonorge"


### PR DESCRIPTION
Denne PRen setter security champion i git-repoet ved å legge til `@dagolav` i CODEOWNER-filen.
Videre opprettes description-filen under .security-mappen med følgende felter:

```
organization: Land
product: GeoNorge
repo_types: [InternalApi,InternalClient,Experiment]
platforms: [LOKALT]
```

Oppretter også `catalog-info.yaml` hvis den ikke finnes fra før. Dette gjør at repoet kan legges inn inn i utviklerportalen [kartverket.dev](https://kartverket.dev/).

Hvorfor vi gjør dette er beskrevet [her i Sikkerhetshåndboka](https://kartverket.atlassian.net/wiki/spaces/SIK/pages/732397586/Sikkerhet+i+repoet) hvorfor vi gjør dette.